### PR TITLE
Bugfix/parameterised path cors

### DIFF
--- a/generators/endpoint-cors/index.js
+++ b/generators/endpoint-cors/index.js
@@ -5,6 +5,7 @@ const inquirer = require('inquirer');
 const ejs = require('ejs');
 const fs = require('fs');
 const _ = require('lodash');
+const helpers = require('../../lib/helper');
 
 /**
  *  Generator for enabling CORS on an existing endpoint, modifies
@@ -171,8 +172,19 @@ module.exports = generators.Base.extend({
         };
 
         // Create the OPTIONS method
+        const pathParameters = helpers.extractURLParameters(this.path);
+        const parameters = pathParameters.map(function(param) {
+            let key = _.camelCase(param) + 'Path';
+            key = key.charAt(0).toUpperCase() + key.substring(1);
+
+            return {
+                '$ref': '#/parameters/' + key
+            };
+        });
+
         const template = fs.readFileSync(this.templatePath('api.json'), 'utf8');
         const rendered = ejs.render(template, {
+            parameters: parameters,
             responseParameters: responseParameters
         });
         this.endpoint['options'] = JSON.parse(rendered);

--- a/generators/endpoint-cors/templates/api.json
+++ b/generators/endpoint-cors/templates/api.json
@@ -15,6 +15,7 @@
             }
         }
     },
+    "parameters": <%- JSON.stringify(parameters) %>,
     "x-amazon-apigateway-auth": {
         "type": "none"
     },

--- a/test/endpoint-cors-test.js
+++ b/test/endpoint-cors-test.js
@@ -79,7 +79,8 @@ describe('lambda-tools:endpoint-cors', function() {
                     'method.response.header.Access-Control-Allow-Origin': '\'*\'',
                     'method.response.header.Access-Control-Allow-Headers': '\'Content-Type,X-Amz-Date,X-Api-Key,Authorization,X-Page\'',
                     'method.response.header.Access-Control-Allow-Methods': '\'PUT,GET,OPTIONS\''
-                }
+                },
+                parameters: []
             });
         });
 
@@ -128,6 +129,79 @@ describe('lambda-tools:endpoint-cors', function() {
         });
     });
 
+    describe('With parameterised path and all headers', function() {
+        before(function(done) {
+            this.prompts = {
+                path: '/{foo}',
+                allowMethods: ['POST'],
+                allowHeaders: ['Content-Type', 'X-Amz-Date', 'X-Api-Key', 'Authorization', 'X-Page']
+            };
+
+            runGenerator(this.prompts, done);
+        });
+
+        it('adds options entry to api.json', function() {
+            // Should be relatively redundant, but nevertheless
+            assert.file('api.json');
+
+            // Actual validation of the entry in api.json
+            validateOptionsEntry('/{foo}', {
+                responseParameters: {
+                    'method.response.header.Access-Control-Allow-Origin': '\'*\'',
+                    'method.response.header.Access-Control-Allow-Headers': '\'Content-Type,X-Amz-Date,X-Api-Key,Authorization,X-Page\'',
+                    'method.response.header.Access-Control-Allow-Methods': '\'POST,OPTIONS\''
+                },
+                parameters: [{
+                    '$ref': '#/parameters/FooPath'
+                }]
+            });
+        });
+
+        it('updates existing method entries in api.json', function() {
+            // Should be relatively redundant, but nevertheless
+            assert.file('api.json');
+
+            const expectedResponses = {
+                '200': {
+                    description: 'Default response',
+                    schema: {
+                        type: 'object',
+                        properties: {},
+                        additionalProperties: true
+                    },
+                    headers: {
+                        'Access-Control-Allow-Headers': {
+                            type: 'string'
+                        },
+                        'Access-Control-Allow-Methods': {
+                            type: 'string'
+                        },
+                        'Access-Control-Allow-Origin': {
+                            type: 'string'
+                        }
+                    }
+                }
+            };
+
+            const expectedAmazonResponses = {
+                default: {
+                    statusCode: '200',
+                    responseTemplates: {
+                        'application/json': ''
+                    },
+                    responseParameters: {
+                        'method.response.header.Access-Control-Allow-Origin': '\'*\'',
+                        'method.response.header.Access-Control-Allow-Headers': '\'Content-Type,X-Amz-Date,X-Api-Key,Authorization,X-Page\'',
+                        'method.response.header.Access-Control-Allow-Methods': '\'PUT,OPTIONS\''
+                    }
+                }
+            };
+
+            validateUpdatedPathEntry('/', this.prompts.allowMethods,
+                expectedResponses, expectedAmazonResponses);
+        });
+    });
+
     describe('With some methods and all headers', function() {
         before(function(done) {
             this.prompts = {
@@ -149,7 +223,8 @@ describe('lambda-tools:endpoint-cors', function() {
                     'method.response.header.Access-Control-Allow-Origin': '\'*\'',
                     'method.response.header.Access-Control-Allow-Headers': '\'Content-Type,X-Amz-Date,X-Api-Key,Authorization,X-Page\'',
                     'method.response.header.Access-Control-Allow-Methods': '\'PUT,OPTIONS\''
-                }
+                },
+                parameters: []
             });
         });
 
@@ -219,7 +294,8 @@ describe('lambda-tools:endpoint-cors', function() {
                     'method.response.header.Access-Control-Allow-Origin': '\'*\'',
                     'method.response.header.Access-Control-Allow-Headers': '\'Content-Type,Authorization\'',
                     'method.response.header.Access-Control-Allow-Methods': '\'GET,OPTIONS\''
-                }
+                },
+                parameters: []
             });
         });
 
@@ -290,7 +366,8 @@ describe('lambda-tools:endpoint-cors', function() {
                     'method.response.header.Access-Control-Allow-Origin': '\'http://test.com\'',
                     'method.response.header.Access-Control-Allow-Headers': '\'Authorization\'',
                     'method.response.header.Access-Control-Allow-Methods': '\'GET,OPTIONS\''
-                }
+                },
+                parameters: []
             });
         });
 

--- a/test/templates/endpoint-cors.json
+++ b/test/templates/endpoint-cors.json
@@ -73,9 +73,7 @@
                         }
                     }
                 },
-                "parameters": {
-
-                },
+                "parameters": [],
                 "x-amazon-apigateway-auth": {
                     "type": "none"
                 },
@@ -101,7 +99,7 @@
                 }
             }
         },
-        "/foo": {
+        "/{foo}": {
             "post": {
                 "responses": {
                     "200": {
@@ -113,9 +111,11 @@
                         }
                     }
                 },
-                "parameters": {
-
-                },
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/FooPath"
+                    }
+                ],
                 "x-amazon-apigateway-auth": {
                     "type": "none"
                 },
@@ -143,6 +143,14 @@
         }
     },
     "responses": {},
-    "parameters": {},
+    "parameters": {
+        "FooPath": {
+            "name": "foo",
+            "in": "path",
+            "description": "Foo argument",
+            "required": true,
+            "type": "string"
+        }
+    },
     "definitions": {}
 }


### PR DESCRIPTION
- [X] Issue exists - #14 
- [X] Linter passes (`npm run lint`)
- [X] Tests pass (`npm run test`)
- [X] CircleCI build is green
- [X] Documentation is up to date (README + comments)

Brief overview of changes:
- Make sure `lambda-tools:endpoint-cors` generator adds appropriate path parameters to the OPTIONS method
- Assumes the path parameters were generated by the `lambda-tools:endpoint` generator, i.e they are present in the `parameters` key in the Swagger file and are named as the endpoint generator would name them.
- Updated tests to cover this case.