### PR TITLE
Add default runtime support

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -102,6 +102,37 @@ module.exports = generators.Base.extend({
             }.bind(this));
         },
 
+        runtime: function() {
+            const runtimes = [
+                {
+                    name: 'Node.js 4.3',
+                    value: 'nodejs4.3'
+                },
+                {
+                    name: 'Node.js 0.10 (legacy)',
+                    value: 'nodejs'
+                }
+            ];
+
+            const prompts = [
+                {
+                    type: 'list',
+                    name: 'runtime',
+                    choices: runtimes,
+                    default: 'nodejs4.3'
+                }
+            ];
+
+            const done = this.async();
+            this.prompt(prompts, function(answers) {
+                this.lambda = {
+                    runtime: answers.runtime
+                };
+
+                done();
+            }.bind(this));
+        },
+
         dependencies: function() {
             // Ask about installing dependencies
             const dependencies = [
@@ -170,6 +201,7 @@ module.exports = generators.Base.extend({
 
         const template = {
             service: this.service,
+            lambda: this.lambda,
             author: this.author
         };
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -118,6 +118,7 @@ module.exports = generators.Base.extend({
                 {
                     type: 'list',
                     name: 'runtime',
+                    message: 'Default Lambda runtime',
                     choices: runtimes,
                     default: 'nodejs4.3'
                 }

--- a/generators/app/templates/.lambda-tools-rc.json
+++ b/generators/app/templates/.lambda-tools-rc.json
@@ -2,6 +2,9 @@
     "project": {
         "name": "<%= service.name %>"
     },
+    "lambda": {
+        "runtime": "<%= lambda.runtime %>"
+    },
     "aws": {
         "region": "us-east-1",
         "stage": "dev"

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -7,64 +7,132 @@ const exists = require('is-there');
 const fs = require('fs-extra');
 
 describe('lambda-tools:app', function() {
-    before(function(done) {
-        this.prompts = {
-            serviceName: 'name',
-            serviceDescription: 'description',
-            serviceLicense: 'test-license',
-            authorName: 'author',
-            authorEmail: 'test@test.com',
-            dependencies: []
-        };
+    describe('With modern runtime', function() {
+        before(function(done) {
+            this.prompts = {
+                serviceName: 'name',
+                serviceDescription: 'description',
+                serviceLicense: 'test-license',
+                authorName: 'author',
+                authorEmail: 'test@test.com',
+                dependencies: []
+            };
 
-        helpers.run(path.join(__dirname, '../generators/app'))
-            .inTmpDir(function(dir) {
-                // Make sure there's a stub cf.json file in place
-                fs.copySync(path.join(__dirname, 'templates/package.json'), path.join(dir, 'package.json'), {
-                    clobber: true
-                });
-            })
-            .withPrompts(this.prompts)
-            .on('end', done);
+            helpers.run(path.join(__dirname, '../generators/app'))
+                .inTmpDir(function(dir) {
+                    // Make sure there's a stub cf.json file in place
+                    fs.copySync(path.join(__dirname, 'templates/package.json'), path.join(dir, 'package.json'), {
+                        clobber: true
+                    });
+                })
+                .withPrompts(this.prompts)
+                .on('end', done);
+        });
+
+        it('generates api.json file', function() {
+            assert.file('api.json');
+
+            // Assert that the contents is correct
+            const actual = JSON.parse(fs.readFileSync('api.json'));
+
+            assert.equal(actual.info.title, this.prompts.serviceName);
+            assert.equal(actual.info.description, this.prompts.serviceDescription);
+            assert.equal(actual.info.license.name, this.prompts.serviceLicense);
+            assert.equal(actual.info.contact.name, this.prompts.authorName);
+            assert.equal(actual.info.contact.email, this.prompts.authorEmail);
+        });
+
+        it('generates cf.json file', function() {
+            assert.file('cf.json');
+
+            // Assert that the contents is correct
+            // (namely that the switched in values were correctly inserted)
+            const actual = JSON.parse(fs.readFileSync('cf.json'));
+
+            assert.equal(actual.Description, this.prompts.serviceDescription);
+            assert.equal(actual.Parameters.aaProjectName.Default, this.prompts.serviceName);
+            assert.equal(actual.Parameters.aaProjectName.AllowedValues[0], this.prompts.serviceName);
+        });
+
+        it('generates .lambda-tools-rc.json file', function() {
+            assert.file('.lambda-tools-rc.json');
+
+            // The contents should also be valid
+            const actual = JSON.parse(fs.readFileSync('.lambda-tools-rc.json'));
+
+            assert.equal(actual.project.name, this.prompts.serviceName);
+            assert.equal(actual.aws.stage, 'dev');
+            assert.equal(actual.aws.region, 'us-east-1');
+            assert.equal(actual.lambda.runtime, 'nodejs4.3');
+        });
+
+        it('generates lambdas directory', function() {
+            assert(exists('lambdas'));
+        });
     });
 
-    it('generates api.json file', function() {
-        assert.file('api.json');
+    describe('With legacy runtime', function() {
+        before(function(done) {
+            this.prompts = {
+                serviceName: 'name',
+                serviceDescription: 'description',
+                serviceLicense: 'test-license',
+                authorName: 'author',
+                authorEmail: 'test@test.com',
+                dependencies: [],
+                runtime: 'nodejs'
+            };
 
-        // Assert that the contents is correct
-        const actual = JSON.parse(fs.readFileSync('api.json'));
+            helpers.run(path.join(__dirname, '../generators/app'))
+                .inTmpDir(function(dir) {
+                    // Make sure there's a stub cf.json file in place
+                    fs.copySync(path.join(__dirname, 'templates/package.json'), path.join(dir, 'package.json'), {
+                        clobber: true
+                    });
+                })
+                .withPrompts(this.prompts)
+                .on('end', done);
+        });
 
-        assert.equal(actual.info.title, this.prompts.serviceName);
-        assert.equal(actual.info.description, this.prompts.serviceDescription);
-        assert.equal(actual.info.license.name, this.prompts.serviceLicense);
-        assert.equal(actual.info.contact.name, this.prompts.authorName);
-        assert.equal(actual.info.contact.email, this.prompts.authorEmail);
-    });
+        it('generates api.json file', function() {
+            assert.file('api.json');
 
-    it('generates cf.json file', function() {
-        assert.file('cf.json');
+            // Assert that the contents is correct
+            const actual = JSON.parse(fs.readFileSync('api.json'));
 
-        // Assert that the contents is correct
-        // (namely that the switched in values were correctly inserted)
-        const actual = JSON.parse(fs.readFileSync('cf.json'));
+            assert.equal(actual.info.title, this.prompts.serviceName);
+            assert.equal(actual.info.description, this.prompts.serviceDescription);
+            assert.equal(actual.info.license.name, this.prompts.serviceLicense);
+            assert.equal(actual.info.contact.name, this.prompts.authorName);
+            assert.equal(actual.info.contact.email, this.prompts.authorEmail);
+        });
 
-        assert.equal(actual.Description, this.prompts.serviceDescription);
-        assert.equal(actual.Parameters.aaProjectName.Default, this.prompts.serviceName);
-        assert.equal(actual.Parameters.aaProjectName.AllowedValues[0], this.prompts.serviceName);
-    });
+        it('generates cf.json file', function() {
+            assert.file('cf.json');
 
-    it('generates .lambda-tools-rc.json file', function() {
-        assert.file('.lambda-tools-rc.json');
+            // Assert that the contents is correct
+            // (namely that the switched in values were correctly inserted)
+            const actual = JSON.parse(fs.readFileSync('cf.json'));
 
-        // The contents should also be valid
-        const actual = JSON.parse(fs.readFileSync('.lambda-tools-rc.json'));
+            assert.equal(actual.Description, this.prompts.serviceDescription);
+            assert.equal(actual.Parameters.aaProjectName.Default, this.prompts.serviceName);
+            assert.equal(actual.Parameters.aaProjectName.AllowedValues[0], this.prompts.serviceName);
+        });
 
-        assert.equal(actual.project.name, this.prompts.serviceName);
-        assert.equal(actual.aws.stage, 'dev');
-        assert.equal(actual.aws.region, 'us-east-1');
-    });
+        it('generates .lambda-tools-rc.json file', function() {
+            assert.file('.lambda-tools-rc.json');
 
-    it('generates lambdas directory', function() {
-        assert(exists('lambdas'));
+            // The contents should also be valid
+            const actual = JSON.parse(fs.readFileSync('.lambda-tools-rc.json'));
+
+            assert.equal(actual.project.name, this.prompts.serviceName);
+            assert.equal(actual.aws.stage, 'dev');
+            assert.equal(actual.aws.region, 'us-east-1');
+            assert.equal(actual.lambda.runtime, 'nodejs');
+        });
+
+        it('generates lambdas directory', function() {
+            assert(exists('lambdas'));
+        });
     });
 });


### PR DESCRIPTION
- [X] Issue exists - Internal Asana
- [X] Linter passes (`npm run lint`)
- [X] Tests pass (`npm run test`)
- [X] CircleCI build is green
- [X] Documentation is up to date (README + comments)

Brief overview of changes:
- The main app generator now also asks for the default runtime, with two Node.js options listed.
- The default runtime is the modern one, which differs from what it used to be in LT

This PR depends on https://github.com/Testlio/lambda-tools/pull/33 to be useful, otherwise the choice is not enforced.